### PR TITLE
Removes deprecated jshint property 'es5'.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -5,7 +5,6 @@
     "maxcomplexity": 8,
     "node": true,
     "browser": true,
-    "es5": true,
     "esnext": true,
     "bitwise": true,
     "curly": true,


### PR DESCRIPTION
Fixes #12
