### PR TITLE
Changes the example karma.conf.js coverageReporter type to json.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This snippet from a karma.config.js will output the report and JSON files into a
 
 ```js
 coverageReporter = {
-  type: 'html',
+  type: 'json',
   dir: 'test/coverage'
 };
 ```


### PR DESCRIPTION
Using HTML will not actually work, and cause the coverage check to fail when asserting the .json coverage file is present.
