### PR TITLE
Update failure output message format

### DIFF
--- a/tasks/helpers.js
+++ b/tasks/helpers.js
@@ -56,7 +56,7 @@ exports.init = function (grunt, silent) {
             var passed = false;
             //check result
             if (err) {
-                if (!silent) { grunt.fail.warn(err); }
+                if (!silent) { grunt.fail.warn('\n' + err + '\n\n'); }
             } else {
                 passed = true;
             }


### PR DESCRIPTION
Fixes #24


**Current format:**

```
Warning: ERROR: Coverage for statements (15.59%) does not meet global threshold (70%)
ERROR: Coverage for branches (2.91%) does not meet global threshold (70%)
ERROR: Coverage for lines (15.63%) does not meet global threshold (70%)
ERROR: Coverage for functions (7.46%) does not meet global threshold (70%) Use --force to continue.

Aborted due to warnings.
```


**Proposed format:**

```
Warning:
ERROR: Coverage for statements (15.59%) does not meet global threshold (70%)
ERROR: Coverage for branches (2.91%) does not meet global threshold (70%)
ERROR: Coverage for lines (15.63%) does not meet global threshold (70%)
ERROR: Coverage for functions (7.46%) does not meet global threshold (70%)

Use --force to continue.

Aborted due to warnings.
```
