### PR TITLE
Update Istanbul dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
     "grunt": "^0.4.5",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-nodeunit": "^0.4.1",
-    "istanbul": "^0.3.5"
+    "istanbul": "^0.4.2"
   },
   "dependencies": {
-    "istanbul": "^0.3.5"
+    "istanbul": "^0.4.2"
   },
   "peerDependencies": {
     "grunt": "^0.4.5"


### PR DESCRIPTION
It turns out that the NPM semver caret ranges (e.g. `^0.3.5`) work differently on version numbers that begin with `0.` (or `0.0.`) than what I personally expected.

From the [NPM docs](https://docs.npmjs.com/misc/semver#caret-ranges-1-2-3-0-2-5-0-0-4):
 - **`^1.2.3`** ` := ` **`>=1.2.3 <2.0.0`**
 - **`^0.2.3`** ` := ` **`>=0.2.3 <0.3.0`**
 - **`^0.0.3`** ` := ` **`>=0.0.3 <0.0.4`**

As such, your current version specified for the Istanbul dependency (`^0.3.5`) only covers `>=0.3.5 <0.4.0`, whereas I expected it to cover `>=0.3.5 <1.0.0`.